### PR TITLE
Update core contracts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@fractal-framework/metafactory",
       "version": "0.1.0",
       "devDependencies": {
-        "@fractal-framework/core-contracts": "^0.1.1",
+        "@fractal-framework/core-contracts": "^0.1.2",
         "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@^0.3.0-beta.13",
         "@nomiclabs/hardhat-etherscan": "^2.1.8",
         "@nomiclabs/hardhat-waffle": "^2.0.1",
@@ -1241,9 +1241,9 @@
       }
     },
     "node_modules/@fractal-framework/core-contracts": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@fractal-framework/core-contracts/-/core-contracts-0.1.1.tgz",
-      "integrity": "sha512-S7jTIAlA5Tv6dSgbrbfQlcjY0WDG63y04MNzT87OM3XVMIV0IwXqPSocTiv0TdO4yMRupLhDncgUFw73SCJlSg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@fractal-framework/core-contracts/-/core-contracts-0.1.2.tgz",
+      "integrity": "sha512-uDPvqsihfLXB57UZ6XcwlPcZuDoircpNqFNLt5405qgu2UWBPL7t6hhu0bBTXPXQPqazKVxCP8Zkn91ZyJVUGA==",
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -23617,9 +23617,9 @@
       }
     },
     "@fractal-framework/core-contracts": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@fractal-framework/core-contracts/-/core-contracts-0.1.1.tgz",
-      "integrity": "sha512-S7jTIAlA5Tv6dSgbrbfQlcjY0WDG63y04MNzT87OM3XVMIV0IwXqPSocTiv0TdO4yMRupLhDncgUFw73SCJlSg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@fractal-framework/core-contracts/-/core-contracts-0.1.2.tgz",
+      "integrity": "sha512-uDPvqsihfLXB57UZ6XcwlPcZuDoircpNqFNLt5405qgu2UWBPL7t6hhu0bBTXPXQPqazKVxCP8Zkn91ZyJVUGA==",
       "dev": true
     },
     "@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "hardhat test"
   },
   "devDependencies": {
-    "@fractal-framework/core-contracts": "^0.1.1",
+    "@fractal-framework/core-contracts": "^0.1.2",
     "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@^0.3.0-beta.13",
     "@nomiclabs/hardhat-etherscan": "^2.1.8",
     "@nomiclabs/hardhat-waffle": "^2.0.1",

--- a/test/MetaFactory.test.ts
+++ b/test/MetaFactory.test.ts
@@ -323,7 +323,7 @@ describe("MetaFactory", () => {
     );
 
     const innerAddActionsRolesCalldata =
-      accessControl.interface.encodeFunctionData("addActionsRoles", [
+      accessControl.interface.encodeFunctionData("daoAddActionsRoles", [
         [
           predictedTreasuryAddress,
           predictedTreasuryAddress,
@@ -374,7 +374,7 @@ describe("MetaFactory", () => {
     );
 
     const revokeMetafactoryRoleCalldata =
-      accessControl.interface.encodeFunctionData("renounceRole", [
+      accessControl.interface.encodeFunctionData("userRenounceRole", [
         "EXECUTE_ROLE",
         metaFactory.address,
       ]);


### PR DESCRIPTION
This PR: 
 - Updates the fractal core contracts package version to 0.1.2
 - Updates the test to support the new access control function names